### PR TITLE
BREAKING CHANGES: New Vixen-js React API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vixen-js/core-react",
   "private": false,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Vixen UI Core React Package to create Desktop apps using react.js",
   "type": "module",
   "types": "dist/main.d.ts",
@@ -23,7 +23,7 @@
     "prepublishOnly": "$npm_execpath build"
   },
   "peerDependencies": {
-    "@vixen-js/core": "^0.1.3",
+    "@vixen-js/core": "^0.3.2",
     "react": "^18.3.1"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^0.28.8
     version: 0.28.8
   '@vixen-js/core':
-    specifier: ^0.1.3
-    version: 0.1.3
+    specifier: ^0.3.2
+    version: 0.3.2
   react-deep-force-update:
     specifier: ^2.1.3
     version: 2.1.3
@@ -634,15 +634,15 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@vixen-js/core@0.1.3:
-    resolution: {integrity: sha512-Eu/L6utVETFXHKLzBqRUc1RAz7MrtEdmvJWIvTxPaKV3iPjgCIG/XUQ9lyGB/GAGZxg2RF1+Z6fAU8Ua7SLmIA==}
+  /@vixen-js/core@0.3.2:
+    resolution: {integrity: sha512-QK41cXWvfG15vR5gZwrvBZCCIu5jwQaZzZPUvdS9/aZoookoFvSA+sAAyAYSbCsabk+NkJOZiS793qgqhI0hOA==}
     engines: {node: '>=18.12.x'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@nodegui/qode': 18.12.1
       '@paralleldrive/cuid2': 2.2.2
-      '@vixen-js/pkg-installer': 0.2.1
+      '@vixen-js/pkg-installer': 0.3.0
       '@vixen-js/postqcss-autoprefixer': 0.2.0
       bindings: 1.5.0
       cmake-js: 7.3.0
@@ -657,8 +657,8 @@ packages:
       - supports-color
     dev: false
 
-  /@vixen-js/pkg-installer@0.2.1:
-    resolution: {integrity: sha512-1lT6LtIzg2SlTPY4uYHF9EmOK+SrOeIJnXGKkUVMsmOiXPEYPQMKYD10ngY/ffFXC2RM8jBOqXtnQp4tVRiSZA==}
+  /@vixen-js/pkg-installer@0.3.0:
+    resolution: {integrity: sha512-WSJ8Royb5fNV+4AkWdULdcfBs3OYF/Z1Qu5Yi5Kp+l2EIY4FIxJkqy6eig2z29JqdqJkpWsl8mAocZV5lm74Ow==}
     engines: {node: '>=18.9.0'}
     dependencies:
       7zip-min: 1.4.5

--- a/src/components/AbstractButton.ts
+++ b/src/components/AbstractButton.ts
@@ -5,6 +5,9 @@ import {
   QSize
 } from "@vixen-js/core";
 import { ViewProps, setViewProps } from "./View";
+import { addNewEventListener, cleanEventListener } from "src/utils/helpers";
+
+type ButtonSignals = ViewProps & Partial<QAbstractButtonSignals>;
 
 /**
  * The Button component provides ability to add and manipulate native button widgets. It is based on
@@ -27,8 +30,7 @@ import { ViewProps, setViewProps } from "./View";
  * Renderer.render(<App />);
  * ```
  */
-export interface AbstractButtonProps<Signals extends QAbstractButtonSignals>
-  extends ViewProps<Signals> {
+export interface AbstractButtonProps extends ButtonSignals {
   /**
    * Alternative method of providing the button text
    */
@@ -47,12 +49,12 @@ export interface AbstractButtonProps<Signals extends QAbstractButtonSignals>
   iconSize?: QSize;
 }
 
-export function setAbstractButtonProps<Signals extends QAbstractButtonSignals>(
-  widget: QAbstractButton<Signals>,
-  newProps: AbstractButtonProps<Signals>,
-  oldProps: AbstractButtonProps<Signals>
+export function setAbstractButtonProps(
+  widget: QAbstractButton<QAbstractButtonSignals>,
+  newProps: AbstractButtonProps,
+  oldProps: AbstractButtonProps
 ) {
-  const setter: AbstractButtonProps<Signals> = {
+  const setter: AbstractButtonProps = {
     set children(childrenText: string) {
       widget.setText(childrenText);
     },
@@ -64,6 +66,58 @@ export function setAbstractButtonProps<Signals extends QAbstractButtonSignals>(
     },
     set iconSize(iconSize: QSize) {
       widget.setIconSize(iconSize);
+    },
+    set onClick(callback: (checked: boolean) => void) {
+      cleanEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onClick",
+        oldProps.onClick,
+        callback
+      );
+      addNewEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onClick",
+        callback
+      );
+    },
+    set onMousedown(callback: () => void) {
+      cleanEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onMousedown",
+        oldProps.onMousedown,
+        callback
+      );
+      addNewEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onMousedown",
+        callback
+      );
+    },
+    set onMouseup(callback: () => void) {
+      cleanEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onMouseup",
+        oldProps.onMouseup,
+        callback
+      );
+      addNewEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onMouseup",
+        callback
+      );
+    },
+    set onToggle(callback: (checked: boolean) => void) {
+      cleanEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onToggle",
+        oldProps.onToggle,
+        callback
+      );
+      addNewEventListener<keyof QAbstractButtonSignals>(
+        widget,
+        "onToggle",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Action.ts
+++ b/src/components/Action.ts
@@ -14,21 +14,20 @@ import {
   VProps
 } from "./Config";
 import {
-  addNewEventListeners,
-  cleanEventListenerMap,
+  addNewEventListener,
+  cleanEventListener,
   throwUnsupported
 } from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface ActionProps extends VProps {
+export interface ActionProps extends VProps, Partial<QActionSignals> {
   checkable?: boolean;
   checked?: boolean;
   enabled?: boolean;
   font?: QFont;
   icon?: QIcon;
   id?: string;
-  on?: Partial<QActionSignals>;
   separator?: boolean;
   shortcut?: QKeySequence;
   shortcutContext?: ShortcutContext;
@@ -59,14 +58,6 @@ const setActionProps = (
     set id(id: string) {
       widget.setObjectName(id);
     },
-    set on(listeners: Partial<QActionSignals>) {
-      const listenMap: any = { ...listeners };
-      const oldListenMap: any = { ...oldProps.on };
-      // Clean previous listeners
-      cleanEventListenerMap(widget, oldListenMap, listenMap);
-      // Add new listeners
-      addNewEventListeners(widget, listenMap);
-    },
     set separator(separator: boolean) {
       widget.setSeparator(separator);
     },
@@ -78,8 +69,51 @@ const setActionProps = (
     },
     set text(text: string) {
       widget.setText(text);
+    },
+    // Set Event Listeners
+    set onChange(callbackFn: () => void) {
+      cleanEventListener<keyof QActionSignals>(
+        widget,
+        "onChange",
+        oldProps.onChange,
+        callbackFn
+      );
+      addNewEventListener<keyof QActionSignals>(widget, "onChange", callbackFn);
+    },
+    set onTrigger(callbackFn: (checked: boolean) => void) {
+      cleanEventListener<keyof QActionSignals>(
+        widget,
+        "onTrigger",
+        oldProps.onChange,
+        callbackFn
+      );
+      addNewEventListener<keyof QActionSignals>(
+        widget,
+        "onTrigger",
+        callbackFn
+      );
+    },
+    set onHover(callbackFn: () => void) {
+      cleanEventListener<keyof QActionSignals>(
+        widget,
+        "onHover",
+        oldProps.onHover,
+        callbackFn
+      );
+      addNewEventListener<keyof QActionSignals>(widget, "onHover", callbackFn);
+    },
+    set onToggle(callbackFn: (checked: boolean) => void) {
+      cleanEventListener<keyof QActionSignals>(
+        widget,
+        "onToggle",
+        oldProps.onToggle,
+        callbackFn
+      );
+      addNewEventListener<keyof QActionSignals>(widget, "onToggle", callbackFn);
     }
+    // Finish Event Listeners Set
   };
+
   Object.assign(setter, newProps);
 };
 

--- a/src/components/BoxView.ts
+++ b/src/components/BoxView.ts
@@ -16,7 +16,9 @@ import {
 import { Fiber } from "react-reconciler";
 import { AppContainer, Ctx } from "../reconciler";
 
-export interface BoxViewProps extends ViewProps<QBoxLayoutSignals> {
+type BoxViewSignals = ViewProps & Partial<QBoxLayoutSignals>;
+
+export interface BoxViewProps extends BoxViewSignals {
   direction?: Direction;
 }
 

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -11,6 +11,8 @@ import { throwUnsupported } from "../utils/helpers";
 import { AppContainer, Ctx } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
+type ButtonSignals = AbstractButtonProps & Partial<QPushButtonSignals>;
+
 /**
  * The Button component provides ability to add and manipulate native button widgets.
  * ## Example
@@ -30,7 +32,7 @@ import { Fiber } from "react-reconciler";
  * Renderer.render(<App />);
  * ```
  */
-export interface ButtonProps extends AbstractButtonProps<QPushButtonSignals> {
+export interface ButtonProps extends ButtonSignals {
   /**
    * Check if the button has border raised.
    */

--- a/src/components/Calendar.ts
+++ b/src/components/Calendar.ts
@@ -1,6 +1,7 @@
 import {
   DayOfWeek,
   QCalendarWidgetSignals,
+  QDate,
   QFont,
   QWidget
 } from "@vixen-js/core";
@@ -17,11 +18,16 @@ import {
   VComponent,
   VProps
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface CalendarProps extends ViewProps<QCalendarWidgetSignals> {
+type CalendarSignals = ViewProps & Partial<QCalendarWidgetSignals>;
+export interface CalendarProps extends CalendarSignals {
   dateEditAcceptDelay?: number;
   dateEditEnabled?: boolean;
   gridVisible?: boolean;
@@ -68,6 +74,58 @@ const setCalendarProps = (
     },
     set selectionMode(mode: SelectionMode) {
       widget.setSelectionMode(mode);
+    },
+    set onActivate(callback: (date: QDate) => void) {
+      cleanEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onActivate",
+        oldProps.onActivate,
+        callback
+      );
+      addNewEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onActivate",
+        callback
+      );
+    },
+    set onClick(callback: (date: QDate) => void) {
+      cleanEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onClick",
+        oldProps.onClick,
+        callback
+      );
+      addNewEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onClick",
+        callback
+      );
+    },
+    set onCurrentPageChange(callback: (year: number, month: number) => void) {
+      cleanEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onCurrentPageChange",
+        oldProps.onCurrentPageChange,
+        callback
+      );
+      addNewEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onCurrentPageChange",
+        callback
+      );
+    },
+    set onSelectionChange(callback: () => void) {
+      cleanEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onSelectionChange",
+        oldProps.onSelectionChange,
+        callback
+      );
+      addNewEventListener<keyof QCalendarWidgetSignals>(
+        widget,
+        "onSelectionChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Checkbox.ts
+++ b/src/components/Checkbox.ts
@@ -7,10 +7,15 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
+type CheckboxSignals = AbstractButtonProps & Partial<QCheckBoxSignals>;
 /**
  * The Checkbox component provides ability to add and manipulate native button widgets.
  * ## Example
@@ -30,7 +35,7 @@ import { AppContainer } from "../reconciler";
  * Renderer.render(<App />);
  * ```
  */
-export interface CheckboxProps extends AbstractButtonProps<QCheckBoxSignals> {
+export interface CheckboxProps extends CheckboxSignals {
   checked?: boolean;
 }
 
@@ -42,6 +47,19 @@ const setCheckboxProps = (
   const setter: CheckboxProps = {
     set checked(checked: boolean) {
       widget.setChecked(checked);
+    },
+    set onStateChange(callbackFn: (state: number) => void) {
+      cleanEventListener<keyof QCheckBoxSignals>(
+        widget,
+        "onStateChange",
+        oldProps.onStateChange,
+        callbackFn
+      );
+      addNewEventListener<keyof QCheckBoxSignals>(
+        widget,
+        "onStateChange",
+        callbackFn
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/ColorDialog.ts
+++ b/src/components/ColorDialog.ts
@@ -12,12 +12,17 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { DialogProps, setDialogProps } from "./Dialog";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface ColorDialogProps extends DialogProps<QColorDialogSignals> {
+type ColorDialogSignals = DialogProps & Partial<QColorDialogSignals>;
+export interface ColorDialogProps extends ColorDialogSignals {
   currentColor?: QColor;
   option?: DialogOption<ColorDialogOption>;
   options?: ColorDialogOption;
@@ -37,6 +42,32 @@ const setColorDialogProps = (
     },
     set options(options: ColorDialogOption) {
       widget.setOptions(options);
+    },
+    set onColorSelect(callback: (color: QColor) => void) {
+      cleanEventListener<keyof QColorDialogSignals>(
+        widget,
+        "onColorSelect",
+        oldProps.onColorSelect,
+        callback
+      );
+      addNewEventListener<keyof QColorDialogSignals>(
+        widget,
+        "onColorSelect",
+        callback
+      );
+    },
+    set onCurrentColorChange(callback: (color: QColor) => void) {
+      cleanEventListener<keyof QColorDialogSignals>(
+        widget,
+        "onCurrentColorChange",
+        oldProps.onCurrentColorChange,
+        callback
+      );
+      addNewEventListener<keyof QColorDialogSignals>(
+        widget,
+        "onCurrentColorChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Dial.ts
+++ b/src/components/Dial.ts
@@ -7,9 +7,15 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
+
+type DialSignals = ViewProps & Partial<QDialSignals>;
 
 /**
  * The Dial provides ability to add and manipulate native dial slider widgets. It is based on
@@ -27,8 +33,7 @@ import { AppContainer } from "../reconciler";
  * Renderer.render(<App />);
  * ```
  */
-
-export interface DialProps extends ViewProps<QDialSignals> {
+export interface DialProps extends DialSignals {
   notchesVisible?: boolean;
   wrapping?: boolean;
   notchTarget?: number;
@@ -48,6 +53,81 @@ const setDialProps = (
     },
     set netchTarget(target: number) {
       widget.setNotchTarget(target);
+    },
+    //Event Listeners
+    set onActionTrigger(callback: (action: number) => void) {
+      cleanEventListener<keyof QDialSignals>(
+        widget,
+        "onActionTrigger",
+        oldProps.onActionTrigger,
+        callback
+      );
+      addNewEventListener<keyof QDialSignals>(
+        widget,
+        "onActionTrigger",
+        callback
+      );
+    },
+    set onRangeChange(callback: (min: number, max: number) => void) {
+      cleanEventListener<keyof QDialSignals>(
+        widget,
+        "onRangeChange",
+        oldProps.onRangeChange,
+        callback
+      );
+      addNewEventListener<keyof QDialSignals>(
+        widget,
+        "onRangeChange",
+        callback
+      );
+    },
+    set onSliderMove(callback: (value: number) => void) {
+      cleanEventListener<keyof QDialSignals>(
+        widget,
+        "onSliderMove",
+        oldProps.onSliderMove,
+        callback
+      );
+      addNewEventListener<keyof QDialSignals>(widget, "onSliderMove", callback);
+    },
+    set onSliderPress(callback: () => void) {
+      cleanEventListener<keyof QDialSignals>(
+        widget,
+        "onSliderPress",
+        oldProps.onSliderPress,
+        callback
+      );
+      addNewEventListener<keyof QDialSignals>(
+        widget,
+        "onSliderPress",
+        callback
+      );
+    },
+    set onSliderRelease(callback: () => void) {
+      cleanEventListener<keyof QDialSignals>(
+        widget,
+        "onSliderRelease",
+        oldProps.onSliderRelease,
+        callback
+      );
+      addNewEventListener<keyof QDialSignals>(
+        widget,
+        "onSliderRelease",
+        callback
+      );
+    },
+    set onValueChange(callback: (value: number) => void) {
+      cleanEventListener<keyof QDialSignals>(
+        widget,
+        "onValueChange",
+        oldProps.onValueChange,
+        callback
+      );
+      addNewEventListener<keyof QDialSignals>(
+        widget,
+        "onValueChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Dialog.ts
+++ b/src/components/Dialog.ts
@@ -16,9 +16,10 @@ import {
 } from "./Config";
 import { AppContainer, Ctx } from "../reconciler";
 import { Fiber } from "react-reconciler";
+import { addNewEventListener, cleanEventListener } from "src/utils/helpers";
 
-export interface DialogProps<T extends object = QDialogSignals>
-  extends ViewProps<T> {
+type DialogSignals = ViewProps & Partial<QDialogSignals>;
+export interface DialogProps extends DialogSignals {
   open?: boolean;
   font?: QFont;
   focus?: FocusReason;
@@ -60,6 +61,34 @@ export const setDialogProps = (
     },
     set enableSizeGrip(enableSizeGrip: boolean) {
       widget.setSizeGripEnabled(enableSizeGrip);
+    },
+    // Event Listeners
+    set onAccept(callback: () => void) {
+      cleanEventListener<keyof QDialogSignals>(
+        widget,
+        "onAccept",
+        oldProps.onAccept,
+        callback
+      );
+      addNewEventListener<keyof QDialogSignals>(widget, "onAccept", callback);
+    },
+    set onFinish(callback: (result: number) => void) {
+      cleanEventListener<keyof QDialogSignals>(
+        widget,
+        "onFinish",
+        oldProps.onFinish,
+        callback
+      );
+      addNewEventListener<keyof QDialogSignals>(widget, "onFinish", callback);
+    },
+    set onReject(callback: () => void) {
+      cleanEventListener<keyof QDialogSignals>(
+        widget,
+        "onReject",
+        oldProps.onReject,
+        callback
+      );
+      addNewEventListener<keyof QDialogSignals>(widget, "onReject", callback);
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/ErrorPrompt.ts
+++ b/src/components/ErrorPrompt.ts
@@ -11,7 +11,8 @@ import { throwUnsupported } from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface ErrorPromptProps extends DialogProps<QErrorMessageSignals> {
+type ErrorPromptSignals = DialogProps & Partial<QErrorMessageSignals>;
+export interface ErrorPromptProps extends ErrorPromptSignals {
   message: string;
 }
 

--- a/src/components/FileDialog.ts
+++ b/src/components/FileDialog.ts
@@ -13,7 +13,11 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
@@ -27,7 +31,9 @@ export interface DialogOptions<T = Option> {
   on: boolean;
 }
 
-export interface FileDialogProps extends DialogProps<QFileDialogSignals> {
+type FileDialogSignals = DialogProps & Partial<QFileDialogSignals>;
+
+export interface FileDialogProps extends FileDialogSignals {
   defaultSuffix?: string;
   supportedSchemes?: string[];
   labelText?: FileDialogLabelText;
@@ -56,6 +62,123 @@ const setFielDialogProps = (
     },
     set options(options: Option) {
       widget.setOptions(options);
+    },
+    set onCurrentChange(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onCurrentChange",
+        oldProps.onCurrentChange,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onCurrentChange",
+        callback
+      );
+    },
+    set onCurrentUrlChange(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onCurrentUrlChange",
+        oldProps.onCurrentUrlChange,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onCurrentUrlChange",
+        callback
+      );
+    },
+    set onDirectoryEnter(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onDirectoryEnter",
+        oldProps.onDirectoryEnter,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onDirectoryEnter",
+        callback
+      );
+    },
+    set onDirectoryUrlEnter(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onDirectoryUrlEnter",
+        oldProps.onDirectoryUrlEnter,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onDirectoryUrlEnter",
+        callback
+      );
+    },
+    set onFileSelect(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onFileSelect",
+        oldProps.onFileSelect,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onFileSelect",
+        callback
+      );
+    },
+    set onFilesSelect(callback: (value: string[]) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onFilesSelect",
+        oldProps.onFilesSelect,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onFilesSelect",
+        callback
+      );
+    },
+    set onFilterSelect(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onFilterSelect",
+        oldProps.onFilterSelect,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onFilterSelect",
+        callback
+      );
+    },
+    set onUrlSelect(callback: (value: string) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onUrlSelect",
+        oldProps.onUrlSelect,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onUrlSelect",
+        callback
+      );
+    },
+    set onUrlsSelect(callback: (value: string[]) => void) {
+      cleanEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onUrlsSelect",
+        oldProps.onUrlsSelect,
+        callback
+      );
+      addNewEventListener<keyof QFileDialogSignals>(
+        widget,
+        "onUrlsSelect",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/FontDialog.ts
+++ b/src/components/FontDialog.ts
@@ -14,11 +14,16 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface FontDialogProps extends DialogProps<QFontDialogSignals> {
+type FontDialogSignals = DialogProps & Partial<QFontDialogSignals>;
+export interface FontDialogProps extends FontDialogSignals {
   currentFont?: QFont;
   option?: DialogOption<FontDialogOption>;
   options?: FontDialogOption;
@@ -38,6 +43,32 @@ const setFontDialogProps = (
     },
     set options(options: FontDialogOption) {
       widget.setOptions(options);
+    },
+    set onFontSelect(callback: (font: QFont) => void) {
+      cleanEventListener<keyof QFontDialogSignals>(
+        widget,
+        "onFontSelect",
+        oldProps.onFontSelect,
+        callback
+      );
+      addNewEventListener<keyof QFontDialogSignals>(
+        widget,
+        "onFontSelect",
+        callback
+      );
+    },
+    set onCurrentFontChange(callback: (font: QFont) => void) {
+      cleanEventListener<keyof QFontDialogSignals>(
+        widget,
+        "onCurrentFontChange",
+        oldProps.onCurrentFontChange,
+        callback
+      );
+      addNewEventListener<keyof QFontDialogSignals>(
+        widget,
+        "onCurrentFontChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -136,7 +136,7 @@ class ImageConfig extends ComponentConfig {
     const widget = new VImage();
     widget.setProperty("scaledContents", true);
     widget.setProps(props, {});
-    widget.addEventListener(WidgetEventTypes.Resize, () => {
+    widget.addEventListener(WidgetEventTypes.onResize, () => {
       widget.scalePixmap(widget.size());
     });
     return widget;

--- a/src/components/InputDialog.ts
+++ b/src/components/InputDialog.ts
@@ -14,11 +14,16 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface InputDialogProps extends DialogProps<QInputDialogSignals> {
+type InputDialogSignals = DialogProps & Partial<QInputDialogSignals>;
+export interface InputDialogProps extends InputDialogSignals {
   cancelButtonText?: string;
   selectEditable?: boolean;
   doubleDecimals?: number;
@@ -90,6 +95,84 @@ const setInputDialogProps = (
     },
     set textValue(text: string) {
       widget.setTextValue(text);
+    },
+    set onDoubleValueChange(callback: (value: number) => void) {
+      cleanEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onDoubleValueChange",
+        oldProps.onDoubleValueChange,
+        callback
+      );
+      addNewEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onDoubleValueChange",
+        callback
+      );
+    },
+    set onDoubleValueSelect(callback: (value: number) => void) {
+      cleanEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onDoubleValueSelect",
+        oldProps.onDoubleValueSelect,
+        callback
+      );
+      addNewEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onDoubleValueSelect",
+        callback
+      );
+    },
+    set onIntValueChange(callback: (value: number) => void) {
+      cleanEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onIntValueChange",
+        oldProps.onIntValueChange,
+        callback
+      );
+      addNewEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onIntValueChange",
+        callback
+      );
+    },
+    set onIntValueSelect(callback: (value: number) => void) {
+      cleanEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onIntValueSelect",
+        oldProps.onIntValueSelect,
+        callback
+      );
+      addNewEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onIntValueSelect",
+        callback
+      );
+    },
+    set onTextValueChange(callback: (text: string) => void) {
+      cleanEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onTextValueChange",
+        oldProps.onTextValueChange,
+        callback
+      );
+      addNewEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onTextValueChange",
+        callback
+      );
+    },
+    set onTextValueSelect(callback: (text: string) => void) {
+      cleanEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onTextValueSelect",
+        oldProps.onTextValueSelect,
+        callback
+      );
+      addNewEventListener<keyof QInputDialogSignals>(
+        widget,
+        "onTextValueSelect",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/LineEdit.ts
+++ b/src/components/LineEdit.ts
@@ -7,9 +7,15 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
+
+type LineEditSignals = ViewProps & Partial<QLineEditSignals>;
 
 /**
  * The LineEdit component provides ability to add and manipulate native editable text field widgets. It is based on
@@ -30,7 +36,7 @@ import { AppContainer } from "../reconciler";
  * Renderer.render(<App />);
  * ```
  */
-export interface LineEditProps extends ViewProps<QLineEditSignals> {
+export interface LineEditProps extends LineEditSignals {
   text?: string;
   placeholderText?: string;
   readOnly?: boolean;
@@ -54,6 +60,100 @@ const setLineEditProps = (
     },
     set echoMode(echoMode: EchoMode) {
       widget.setEchoMode(echoMode);
+    },
+    // Event handlers
+    set onCursorPositionChange(
+      callback: (oldPos: number, newPos: number) => void
+    ) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onCursorPositionChange",
+        oldProps.onCursorPositionChange,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onCursorPositionChange",
+        callback
+      );
+    },
+    set onEditingFinish(callback: () => void) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onEditingFinish",
+        oldProps.onEditingFinish,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onEditingFinish",
+        callback
+      );
+    },
+    set onInputReject(callback: () => void) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onInputReject",
+        oldProps.onInputReject,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onInputReject",
+        callback
+      );
+    },
+    set onReturnPress(callback: () => void) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onReturnPress",
+        oldProps.onReturnPress,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onReturnPress",
+        callback
+      );
+    },
+    set onSelectionChange(callback: () => void) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onSelectionChange",
+        oldProps.onSelectionChange,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onSelectionChange",
+        callback
+      );
+    },
+    set onTextChange(callback: (text: string) => void) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onTextChange",
+        oldProps.onTextChange,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onTextChange",
+        callback
+      );
+    },
+    set onTextEdit(callback: (text: string) => void) {
+      cleanEventListener<keyof QLineEditSignals>(
+        widget,
+        "onTextEdit",
+        oldProps.onTextEdit,
+        callback
+      );
+      addNewEventListener<keyof QLineEditSignals>(
+        widget,
+        "onTextEdit",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/List.ts
+++ b/src/components/List.ts
@@ -1,6 +1,7 @@
 import {
   FlexLayout,
   QListWidget,
+  QListWidgetItem,
   QListWidgetSignals,
   QWidget
 } from "@vixen-js/core";
@@ -14,15 +15,149 @@ import {
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 import { VListItem } from "./ListItem";
+import { addNewEventListener, cleanEventListener } from "src/utils/helpers";
 
-export type ListProps = ViewProps<QListWidgetSignals>;
+export type ListProps = ViewProps & Partial<QListWidgetSignals>;
 
 export const setListProps = (
   widget: VList,
   newProps: ListProps,
   oldProps: ListProps
 ) => {
-  const setter: ListProps = {};
+  const setter: ListProps = {
+    set onCurrentItemChange(
+      callback: (current: QListWidgetItem, previous: QListWidgetItem) => void
+    ) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onCurrentItemChange",
+        oldProps.onCurrentItemChange,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onCurrentItemChange",
+        callback
+      );
+    },
+    set onCurrentRowChange(callback: (currentRow: number) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onCurrentRowChange",
+        oldProps.onCurrentRowChange,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onCurrentRowChange",
+        callback
+      );
+    },
+    set onCurrentTextChange(callback: (currentText: string) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onCurrentTextChange",
+        oldProps.onCurrentTextChange,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onCurrentTextChange",
+        callback
+      );
+    },
+    set onItemActivate(callback: (item: QListWidgetItem) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemActivate",
+        oldProps.onItemActivate,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemActivate",
+        callback
+      );
+    },
+    set onItemChange(callback: (item: QListWidgetItem) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemChange",
+        oldProps.onItemChange,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemChange",
+        callback
+      );
+    },
+    set onItemClick(callback: (item: QListWidgetItem) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemClick",
+        oldProps.onItemClick,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemClick",
+        callback
+      );
+    },
+    set onItemDblClick(callback: (item: QListWidgetItem) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemDblClick",
+        oldProps.onItemDblClick,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemDblClick",
+        callback
+      );
+    },
+    set onItemEnter(callback: (item: QListWidgetItem) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemEnter",
+        oldProps.onItemEnter,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemEnter",
+        callback
+      );
+    },
+    set onItemPress(callback: (item: QListWidgetItem) => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemPress",
+        oldProps.onItemPress,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemPress",
+        callback
+      );
+    },
+    set onItemSelectionChange(callback: () => void) {
+      cleanEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemSelectionChange",
+        oldProps.onItemSelectionChange,
+        callback
+      );
+      addNewEventListener<keyof QListWidgetSignals>(
+        widget,
+        "onItemSelectionChange",
+        callback
+      );
+    }
+  };
   Object.assign(setter, newProps);
   setViewProps(widget, newProps, oldProps);
 };

--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -1,4 +1,4 @@
-import { Component, QMenu, QMenuSignals } from "@vixen-js/core";
+import { Component, NativeElement, QMenu, QMenuSignals } from "@vixen-js/core";
 import { setViewProps, ViewProps } from "./View";
 import {
   ComponentConfig,
@@ -8,26 +8,75 @@ import {
   VWidget
 } from "./Config";
 import { VAction } from "./Action";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface MenuProps extends ViewProps<QMenuSignals> {
+type MenuSignals = ViewProps & Partial<QMenuSignals>;
+export interface MenuProps extends MenuSignals {
   title?: string;
 }
 
 const setMenuProps = (
   widget: VMenu,
   newProps: MenuProps,
-  _oldProps: MenuProps
+  oldProps: MenuProps
 ) => {
   const setter: MenuProps = {
     set title(title: string) {
       widget.setTitle(title);
+    },
+    set onAboutToHide(callback: () => void) {
+      cleanEventListener<keyof QMenuSignals>(
+        widget,
+        "onAboutToHide",
+        oldProps.onAboutToHide,
+        callback
+      );
+      addNewEventListener<keyof QMenuSignals>(
+        widget,
+        "onAboutToHide",
+        callback
+      );
+    },
+    set onAboutToShow(callback: () => void) {
+      cleanEventListener<keyof QMenuSignals>(
+        widget,
+        "onAboutToShow",
+        oldProps.onAboutToShow,
+        callback
+      );
+      addNewEventListener<keyof QMenuSignals>(
+        widget,
+        "onAboutToShow",
+        callback
+      );
+    },
+    set onHover(callback: (action: NativeElement) => void) {
+      cleanEventListener<keyof QMenuSignals>(
+        widget,
+        "onHover",
+        oldProps.onHover,
+        callback
+      );
+      addNewEventListener<keyof QMenuSignals>(widget, "onHover", callback);
+    },
+    set onTrigger(callback: (action: NativeElement) => void) {
+      cleanEventListener<keyof QMenuSignals>(
+        widget,
+        "onTrigger",
+        oldProps.onTrigger,
+        callback
+      );
+      addNewEventListener<keyof QMenuSignals>(widget, "onTrigger", callback);
     }
   };
   Object.assign(setter, newProps);
-  setViewProps(widget, newProps, _oldProps);
+  setViewProps(widget, newProps, oldProps);
 };
 
 export class VMenu extends QMenu implements VWidget {

--- a/src/components/MenuBar.ts
+++ b/src/components/MenuBar.ts
@@ -1,4 +1,10 @@
-import { QWidget, QMenu, QMenuBar, QMenuBarSignals } from "@vixen-js/core";
+import {
+  QWidget,
+  QMenu,
+  QMenuBar,
+  QMenuBarSignals,
+  NativeElement
+} from "@vixen-js/core";
 import { setViewProps, ViewProps } from "./View";
 import {
   ComponentConfig,
@@ -7,11 +13,12 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import { cleanEventListener, throwUnsupported } from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface MenuBarProps extends ViewProps<QMenuBarSignals> {
+type MenuBarSignals = ViewProps & Partial<QMenuBarSignals>;
+export interface MenuBarProps extends MenuBarSignals {
   nativeMenuBar?: boolean;
 }
 
@@ -23,6 +30,22 @@ const setMenuBarProps = (
   const setter: MenuBarProps = {
     set nativeMenuBar(nativeMenuBar: boolean) {
       widget.setNativeMenuBar(nativeMenuBar);
+    },
+    set onHover(callback: (action: NativeElement) => void) {
+      cleanEventListener<keyof QMenuBarSignals>(
+        widget,
+        "onHover",
+        oldProps.onHover,
+        callback
+      );
+    },
+    set onTrigger(callback: (action: NativeElement) => void) {
+      cleanEventListener<keyof QMenuBarSignals>(
+        widget,
+        "onTrigger",
+        oldProps.onTrigger,
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/PlainTextEdit.ts
+++ b/src/components/PlainTextEdit.ts
@@ -7,11 +7,16 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer } from "../reconciler";
 
-export interface PlainTextEditProps extends ViewProps<QPlainTextEditSignals> {
+type PlainTextEditSignals = ViewProps & Partial<QPlainTextEditSignals>;
+export interface PlainTextEditProps extends PlainTextEditSignals {
   text?: string;
   readOnly?: boolean;
   placeholder?: string;
@@ -31,6 +36,110 @@ const setPlainTextEditProps = (
     },
     set placeholder(placeholder: string) {
       widget.setPlaceholderText(placeholder);
+    },
+    set onTextChange(callback: () => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onTextChange",
+        oldProps.onTextChange,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onTextChange",
+        callback
+      );
+    },
+    set onBlockCountChange(callback: (blockCount: number) => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onBlockCountChange",
+        oldProps.onBlockCountChange,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onBlockCountChange",
+        callback
+      );
+    },
+    set onCopyAvailable(callback: (yes: boolean) => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onCopyAvailable",
+        oldProps.onCopyAvailable,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onCopyAvailable",
+        callback
+      );
+    },
+    set onCursorPositionChange(callback: () => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onCursorPositionChange",
+        oldProps.onCursorPositionChange,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onCursorPositionChange",
+        callback
+      );
+    },
+    set onModificationChange(callback: (changed: boolean) => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onModificationChange",
+        oldProps.onModificationChange,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onModificationChange",
+        callback
+      );
+    },
+    set onRedoAvailable(callback: (available: boolean) => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onRedoAvailable",
+        oldProps.onRedoAvailable,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onRedoAvailable",
+        callback
+      );
+    },
+    set onSelectionChange(callback: () => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onSelectionChange",
+        oldProps.onSelectionChange,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onSelectionChange",
+        callback
+      );
+    },
+    set onUndoAvailable(callback: (available: boolean) => void) {
+      cleanEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onUndoAvailable",
+        oldProps.onUndoAvailable,
+        callback
+      );
+      addNewEventListener<keyof QPlainTextEditSignals>(
+        widget,
+        "onUndoAvailable",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/ProgressBar.ts
+++ b/src/components/ProgressBar.ts
@@ -12,11 +12,16 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
-export interface ProgressBarProps extends ViewProps<QProgressBarSignals> {
+type ProgressBarSignals = ViewProps & Partial<QProgressBarSignals>;
+export interface ProgressBarProps extends ProgressBarSignals {
   value?: number;
   max?: number;
   min?: number;
@@ -40,6 +45,19 @@ const setProgressBarProps = (
     },
     set orientation(orientation: Orientation) {
       widget.setOrientation(orientation);
+    },
+    set onValueChange(callback: (value: number) => void) {
+      cleanEventListener<keyof QProgressBarSignals>(
+        widget,
+        "onValueChange",
+        oldProps.onValueChange,
+        callback
+      );
+      addNewEventListener<keyof QProgressBarSignals>(
+        widget,
+        "onValueChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/ProgressDialog.ts
+++ b/src/components/ProgressDialog.ts
@@ -5,7 +5,11 @@ import {
 } from "@vixen-js/core";
 import { DialogProps, setDialogProps } from "./Dialog";
 import { ComponentConfig, registerComponent, VWidget } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
@@ -14,8 +18,9 @@ interface ProgressBarRange {
   min: number;
 }
 
-export interface ProgressDialogProps
-  extends DialogProps<QProgressDialogSignals> {
+type ProgreesDialogSignals = DialogProps & Partial<QProgressDialogSignals>;
+
+export interface ProgressDialogProps extends ProgreesDialogSignals {
   autoClose?: boolean;
   autoReset?: boolean;
   cancelButtonText?: string;
@@ -74,6 +79,19 @@ function setProgressDialogProps(
     },
     set value(value: number) {
       widget.setValue(value);
+    },
+    set onCancel(callback: () => void) {
+      cleanEventListener<keyof QProgressDialogSignals>(
+        widget,
+        "onCancel",
+        oldProps.onCancel,
+        callback
+      );
+      addNewEventListener<keyof QProgressDialogSignals>(
+        widget,
+        "onCancel",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/RadioButton.ts
+++ b/src/components/RadioButton.ts
@@ -5,7 +5,8 @@ import { throwUnsupported } from "../utils/helpers";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
-export type RadioButtonProps = AbstractButtonProps<QRadioButtonSignals>;
+export type RadioButtonProps = AbstractButtonProps &
+  Partial<QRadioButtonSignals>;
 
 const setRadioButtonProps = (
   widget: VRadioButton,
@@ -19,9 +20,6 @@ const setRadioButtonProps = (
   setAbstractButtonProps(widget, newProps, oldProps);
 };
 
-/**
- * @ignore
- */
 export class VRadioButton extends QRadioButton implements VWidget {
   static tagName = "radio-button";
   setProps(newProps: RadioButtonProps, oldProps: RadioButtonProps): void {

--- a/src/components/ScrollArea.ts
+++ b/src/components/ScrollArea.ts
@@ -4,7 +4,9 @@ import { ComponentConfig, registerComponent, VWidget } from "./Config";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
-export interface ScrollAreaProps extends ViewProps<QScrollAreaSignals> {
+type ScrollAreaSignals = ViewProps & Partial<QScrollAreaSignals>;
+
+export interface ScrollAreaProps extends ScrollAreaSignals {
   widgetResizable?: boolean;
 }
 

--- a/src/components/Select.ts
+++ b/src/components/Select.ts
@@ -16,7 +16,11 @@ import {
   VProps,
   VWidget
 } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { Fiber } from "react-reconciler";
 import { AppContainer, Ctx } from "../reconciler";
 
@@ -26,7 +30,9 @@ type SelectItem = {
   userData?: QVariant;
 };
 
-export interface SelectProps extends ViewProps<QComboBoxSignals> {
+type SelectSignals = ViewProps & Partial<QComboBoxSignals>;
+
+export interface SelectProps extends SelectSignals {
   items?: SelectItem[];
   count?: number;
   iconSize?: QSize;
@@ -100,6 +106,97 @@ const setSelectProps = (
     },
     set id(id: string) {
       widget.setObjectName(id);
+    },
+    set onActivate(callback: (index: number) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onActivate",
+        oldProps.onActivate,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onActivate",
+        callback
+      );
+    },
+    set onCurrentIndexChange(callback: (index: number) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onCurrentIndexChange",
+        oldProps.onCurrentIndexChange,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onCurrentIndexChange",
+        callback
+      );
+    },
+    set onCurrentTextChange(callback: (text: string) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onCurrentTextChange",
+        oldProps.onCurrentTextChange,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onCurrentTextChange",
+        callback
+      );
+    },
+    set onEditTextChange(callback: (text: string) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onEditTextChange",
+        oldProps.onEditTextChange,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onEditTextChange",
+        callback
+      );
+    },
+    set onHighlight(callback: (index: number) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onHighlight",
+        oldProps.onHighlight,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onHighlight",
+        callback
+      );
+    },
+    set onTextActivate(callback: (text: string) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onTextActivate",
+        oldProps.onTextActivate,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onTextActivate",
+        callback
+      );
+    },
+    set onTextHighlight(callback: (text: string) => void) {
+      cleanEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onTextHighlight",
+        oldProps.onTextHighlight,
+        callback
+      );
+      addNewEventListener<keyof QComboBoxSignals>(
+        widget,
+        "onTextHighlight",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Slider.ts
+++ b/src/components/Slider.ts
@@ -7,11 +7,17 @@ import {
 } from "@vixen-js/core";
 import { setViewProps, ViewProps } from "./View";
 import { ComponentConfig, registerComponent, VWidget } from "./Config";
-import { throwUnsupported } from "../utils/helpers";
+import {
+  addNewEventListener,
+  cleanEventListener,
+  throwUnsupported
+} from "../utils/helpers";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
-export interface SliderProps extends ViewProps<QSliderSignals> {
+type SliderSignals = ViewProps & Partial<QSliderSignals>;
+
+export interface SliderProps extends SliderSignals {
   tickInterval?: number;
   tickPosition?: TickPosition;
   orientation?: Orientation;
@@ -71,6 +77,84 @@ const setSliderProps = (
     },
     set value(value: number) {
       widget.setValue(value);
+    },
+    set onActionTrigger(callback: (action: number) => void) {
+      cleanEventListener<keyof QSliderSignals>(
+        widget,
+        "onActionTrigger",
+        oldProps.onActionTrigger,
+        callback
+      );
+      addNewEventListener<keyof QSliderSignals>(
+        widget,
+        "onActionTrigger",
+        callback
+      );
+    },
+    set onRangeChange(callback: (min: number, max: number) => void) {
+      cleanEventListener<keyof QSliderSignals>(
+        widget,
+        "onRangeChange",
+        oldProps.onRangeChange,
+        callback
+      );
+      addNewEventListener<keyof QSliderSignals>(
+        widget,
+        "onRangeChange",
+        callback
+      );
+    },
+    set onSliderMove(callback: (value: number) => void) {
+      cleanEventListener<keyof QSliderSignals>(
+        widget,
+        "onSliderMove",
+        oldProps.onSliderMove,
+        callback
+      );
+      addNewEventListener<keyof QSliderSignals>(
+        widget,
+        "onSliderMove",
+        callback
+      );
+    },
+    set onSliderPress(callback: () => void) {
+      cleanEventListener<keyof QSliderSignals>(
+        widget,
+        "onSliderPress",
+        oldProps.onSliderPress,
+        callback
+      );
+      addNewEventListener<keyof QSliderSignals>(
+        widget,
+        "onSliderPress",
+        callback
+      );
+    },
+    set onSliderRelease(callback: () => void) {
+      cleanEventListener<keyof QSliderSignals>(
+        widget,
+        "onSliderRelease",
+        oldProps.onSliderRelease,
+        callback
+      );
+      addNewEventListener<keyof QSliderSignals>(
+        widget,
+        "onSliderRelease",
+        callback
+      );
+    },
+    set onValueChange(callback: (value: number) => void) {
+      cleanEventListener<keyof QSliderSignals>(
+        widget,
+        "onValueChange",
+        oldProps.onValueChange,
+        callback
+      );
+      addNewEventListener<keyof QSliderSignals>(
+        widget,
+        "onValueChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Tab.ts
+++ b/src/components/Tab.ts
@@ -10,8 +10,10 @@ import { ComponentConfig, registerComponent, VComponent } from "./Config";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 import { setTabItemProps, VTabItem } from "./TabItem";
+import { addNewEventListener, cleanEventListener } from "src/utils/helpers";
 
-export interface TabProps extends ViewProps<QTabWidgetSignals> {
+type TabSignals = ViewProps & Partial<QTabWidgetSignals>;
+export interface TabProps extends TabSignals {
   tabPosition?: TabPosition;
 }
 
@@ -26,6 +28,58 @@ export const setTabProps = (
   const setter: TabProps = {
     set tabPosition(value: TabPosition) {
       widget.setTabPosition(value);
+    },
+    set onCurrentChange(callback: (index: number) => void) {
+      cleanEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onCurrentChange",
+        oldProps.onCurrentChange,
+        callback
+      );
+      addNewEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onCurrentChange",
+        callback
+      );
+    },
+    set onTabBarClick(callback: (index: number) => void) {
+      cleanEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onTabBarClick",
+        oldProps.onTabBarClick,
+        callback
+      );
+      addNewEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onTabBarClick",
+        callback
+      );
+    },
+    set onTabBarDblClick(callback: (index: number) => void) {
+      cleanEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onTabBarDblClick",
+        oldProps.onTabBarDblClick,
+        callback
+      );
+      addNewEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onTabBarDblClick",
+        callback
+      );
+    },
+    set onTabCloseRequest(callback: (index: number) => void) {
+      cleanEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onTabCloseRequest",
+        oldProps.onTabCloseRequest,
+        callback
+      );
+      addNewEventListener<keyof QTabWidgetSignals>(
+        widget,
+        "onTabCloseRequest",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Table.ts
+++ b/src/components/Table.ts
@@ -11,6 +11,7 @@ import { ComponentConfig, registerComponent, VComponent } from "./Config";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 import { VTableItem } from "./TableItem";
+import { addNewEventListener, cleanEventListener } from "src/utils/helpers";
 
 export interface CellRange {
   row: number;
@@ -39,7 +40,8 @@ interface RowSize extends Omit<CellRange, "column"> {
   width: number;
 }
 
-export interface TableProps extends ViewProps<QTableWidgetSignals> {
+type TableSignals = ViewProps & Partial<QTableWidgetSignals>;
+export interface TableProps extends TableSignals {
   cellRange: CellRange;
   horizontalHeaderItems?: HorizontalHeader[];
   horizontalHeaderLabels?: string[];
@@ -153,6 +155,104 @@ export const setTableProps = (
         verifyRanges(cellRange, { row });
         widget.hideRow(row);
       }
+    },
+    set onCellActivate(callback: (row: number, col: number) => void) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellActivate",
+        oldProps.onCellActivate,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellActivate",
+        callback
+      );
+    },
+    set onCellChange(callback: (row: number, col: number) => void) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellChange",
+        oldProps.onCellChange,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellChange",
+        callback
+      );
+    },
+    set onCellClick(callback: (row: number, col: number) => void) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellClick",
+        oldProps.onCellClick,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellClick",
+        callback
+      );
+    },
+    set onCellDblClick(callback: (row: number, col: number) => void) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellDblClick",
+        oldProps.onCellDblClick,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellDblClick",
+        callback
+      );
+    },
+    set onCellEnter(callback: (row: number, col: number) => void) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellEnter",
+        oldProps.onCellEnter,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellEnter",
+        callback
+      );
+    },
+    set onCellPress(callback: (row: number, col: number) => void) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellPress",
+        oldProps.onCellPress,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCellPress",
+        callback
+      );
+    },
+    set onCurrentCellChange(
+      callback: (
+        currentRow: number,
+        currentColumn: number,
+        previousRow: number,
+        previousColumn: number
+      ) => void
+    ) {
+      cleanEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCurrentCellChange",
+        oldProps.onCurrentCellChange,
+        callback
+      );
+      addNewEventListener<keyof QTableWidgetSignals>(
+        widget,
+        "onCurrentCellChange",
+        callback
+      );
     }
   };
   Object.assign(setter, newProps);

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -10,7 +10,8 @@ import { throwUnsupported } from "../utils/helpers";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
-export interface TextProps extends ViewProps<QLabelSignals> {
+type TextSignals = ViewProps & Partial<QLabelSignals>;
+export interface TextProps extends TextSignals {
   children?: string | number | Array<string | number>;
   wordWrap?: boolean;
   scaledContents?: boolean;

--- a/src/components/Window.ts
+++ b/src/components/Window.ts
@@ -9,7 +9,9 @@ import { ComponentConfig, registerComponent, VProps, VWidget } from "./Config";
 import { AppContainer } from "../reconciler";
 import { Fiber } from "react-reconciler";
 
-export interface WindowProps extends ViewProps<QMainWindowSignals> {
+type WindowSignals = ViewProps & Partial<QMainWindowSignals>;
+
+export interface WindowProps extends WindowSignals {
   menuBar?: QMenuBar;
 }
 

--- a/src/example/demo.tsx
+++ b/src/example/demo.tsx
@@ -1,5 +1,5 @@
 import { QIcon } from "@vixen-js/core";
-import { Image, Text, View } from "../main";
+import { Button, Image, Text, View } from "../main";
 import { Window } from "../components/Window";
 import { Renderer } from "../renderer";
 import styles from "./styles.css?raw";

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -13,23 +13,23 @@ export function isValidUrl(str: string) {
   }
 }
 
-export function cleanEventListenerMap(
+export function cleanEventListener<EventType>(
   widget: any,
-  oldListenMap: any,
-  listenMap: any
+  type: EventType,
+  oldCallback: any,
+  newCallback: any
 ) {
-  Object.entries(oldListenMap).forEach(([type, oldListener]) => {
-    const newListener = listenMap[type];
-    if (oldListener !== newListener) {
-      widget.removeEventListener(type, oldListener);
-    } else {
-      delete listenMap[type];
-    }
-  });
+  if (oldCallback !== newCallback) {
+    widget.removeEventListener(type, oldCallback);
+  } else {
+    delete newCallback[type];
+  }
 }
 
-export function addNewEventListeners(widget: any, listenMap: any) {
-  Object.entries(listenMap).forEach(([type, newListener]) => {
-    widget.addEventListener(type, newListener);
-  });
+export function addNewEventListener<EventType>(
+  widget: any,
+  type: EventType,
+  newCallback: any
+) {
+  widget.addEventListener(type, newCallback);
 }


### PR DESCRIPTION
- Refactored Event System to match `React.js` Like Event System, so now you can use for example `onClick={()=>{...}}` Props inside JDX to bind Click Events.